### PR TITLE
Add trino docker compose

### DIFF
--- a/trino/config/catalog/hive.properties
+++ b/trino/config/catalog/hive.properties
@@ -1,0 +1,8 @@
+connector.name=hive
+hive.metastore.uri=thrift://metastore:9083
+fs.native-s3.enabled=true
+s3.endpoint=http://minio:9000
+s3.region=us-east-1
+s3.path-style-access=true
+s3.aws-access-key=minio
+s3.aws-secret-key=minio123

--- a/trino/docker-compose.yml
+++ b/trino/docker-compose.yml
@@ -1,0 +1,46 @@
+version: '3.7'
+
+services:
+  trino:
+    image: trinodb/trino:latest
+    ports:
+      - "8081:8080"
+    volumes:
+      - ./config/catalog:/etc/trino/catalog
+    depends_on:
+      - minio
+      - metastore
+
+  metastore:
+    image: apache/hive:3.1.3
+    ports:
+      - "9083:9083"
+    environment:
+      - SERVICE_NAME=metastore
+  minio:
+    image: minio/minio
+    ports:
+      - "9000:9000"  # API
+      - "9001:9001"  # Console
+    environment:
+      - MINIO_ROOT_USER=minio
+      - MINIO_ROOT_PASSWORD=minio123
+    command: server --console-address ":9001" /data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
+
+  # Initialize MinIO with a bucket
+  createbuckets:
+    image: minio/mc
+    depends_on:
+      - minio
+    entrypoint: >
+      /bin/sh -c "
+      /usr/bin/mc config host add myminio http://minio:9000 minio minio123;
+      /usr/bin/mc mb myminio/data-bucket;
+      /usr/bin/mc anonymous set public myminio/data-bucket;
+      exit 0;
+      "


### PR DESCRIPTION
- Add the config file for trino
- Add docker compose file starting a trino instance with a minio and a metastore (creating bucket with an ini container)